### PR TITLE
v1.0.1

### DIFF
--- a/ipcmagic/__init__.py
+++ b/ipcmagic/__init__.py
@@ -1,8 +1,9 @@
 from ipcmagic.magics import IPClusterMagics
+from ipcmagic.version import VERSION
 from IPython import get_ipython
 
 
-__version__ = '1.0.1'
+__version__ = VERSION
 
 ip = get_ipython()
 ipcluster_magics = IPClusterMagics(ip)

--- a/ipcmagic/__init__.py
+++ b/ipcmagic/__init__.py
@@ -2,7 +2,7 @@ from ipcmagic.magics import IPClusterMagics
 from IPython import get_ipython
 
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 ip = get_ipython()
 ipcluster_magics = IPClusterMagics(ip)

--- a/ipcmagic/magics.py
+++ b/ipcmagic/magics.py
@@ -1,4 +1,3 @@
-import ipcmagic
 import ipyparallel as ipp
 import os
 import pexpect
@@ -6,6 +5,7 @@ import socket
 import time
 from docopt import docopt, DocoptExit
 from ipcmagic.utilities import Arguments
+from ipcmagic.version import VERSION
 from IPython.core.magic import line_magic, magics_class, Magics
 
 
@@ -28,7 +28,7 @@ class IPClusterMagics(Magics):
     """
     def __init__(self, shell):
         super().__init__(shell)
-        self.__version__ = ipcmagic.__version__
+        self.__version__ = VERSION
         self.running = False
 
     def parse_args(self, line):

--- a/ipcmagic/magics.py
+++ b/ipcmagic/magics.py
@@ -5,6 +5,7 @@ import pexpect
 import socket
 import time
 from docopt import docopt, DocoptExit
+from ipcmagic.utilities import Arguments
 from IPython.core.magic import line_magic, magics_class, Magics
 
 
@@ -12,18 +13,19 @@ from IPython.core.magic import line_magic, magics_class, Magics
 class IPClusterMagics(Magics):
     """Manage an IPyParallel cluster.
 
-Usage:
-  %ipcluster start -n <num_engines> [options]
-  %ipcluster stop
-  %ipcluster (-h | --help)
-  %ipcluster --version
+    Usage:
+      %ipcluster start -n <num_engines> [options]
+      %ipcluster stop
+      %ipcluster (-h | --help)
+      %ipcluster --version
 
-Options:
-  -h --help                Show this screen.
-  -v --version             Show version.
-  -n --num_engines <int>   Number of engines 
-  -m --mpi                 Run with MPI support (engines are distributed across nodes)
-"""
+    Options:
+      -h --help                Show this screen.
+      -v --version             Show version.
+      -n --num_engines <int>   Number of engines
+      -m --mpi                 Run with MPI support (engines are
+                               automatically distributed across nodes)
+    """
     def __init__(self, shell):
         super().__init__(shell)
         self.__version__ = ipcmagic.__version__
@@ -36,6 +38,7 @@ Options:
                           argv=line.split(),
                           version=self.__version__)
         # Invalid syntax
+        # Return `None` when syntax is not valid
         except DocoptExit:
             print("Invalid syntax.")
             print(self.__doc__)
@@ -61,33 +64,23 @@ Options:
 
     def _wait_for_cluster(self, waiting_time):
         try:
-            c = ipp.Client()
+            c = ipp.Client(timeout=10)
         except ipp.TimeoutError:
             self.stop_cluster()
-            print('The connection request to the IPCluster has '
-                  'timed out. Please, start the cluster again.')
-            return -1
+            print('The connection request to the cluster controller '
+                  'has timed out. Please, start the cluster again.')
+            return
 
-        animation = "|/-\\"
-        idx = 0
-        for t in range(waiting_time):
-            polling_rate = 0.4
-            time.sleep(polling_rate)
-            total_sec = t * polling_rate
-            print('Setting up the IPCluster '
-                  f'{animation[idx % len(animation)]}', end='\r')
-            idx += 1
-            if len(c.ids) == int(self._args['num_engines']):
-                print(f'IPCluster is ready! ({total_sec:.0f} seconds)')
-                return 0
-
-        print(f'IPCluster failed to start after {total_sec:.0f} seconds. '
-              'Please, start the cluster again')
-
-        # make sure that no rogue ipc processes are left running
-        # before exitring
-        self.stop_cluster()
-        return -1
+        # at this point the ipcontroller is running and we wait
+        # for the engines to be ready
+        try:
+            c.wait_for_engines(int(self.args.num_engines),
+                               timeout=60)
+        except ipp.TimeoutError:
+            self.stop_cluster()
+            print('IPCMagic has failed to launch the engines. '
+                  'Please, start the cluster again.')
+            return
 
     def _launch_engines_local(self):
         self.controller = pexpect.spawn('ipcontroller --log-to-file')
@@ -97,7 +90,7 @@ Options:
         # started.
         time.sleep(3)
         self.engines = [pexpect.spawn('ipengine --log-to-file')
-                        for i in range(int(self._args['num_engines']))]
+                        for i in range(int(self.args.num_engines))]
         time.sleep(1)
         self.running = True
         self._wait_for_cluster(waiting_time=60)
@@ -112,7 +105,7 @@ Options:
         time.sleep(3)
         hostname = socket.gethostname()
         self.engines = pexpect.spawn(
-            f'srun -n {self._args["num_engines"]} ipengine '
+            f'srun -n {self.args.num_engines} ipengine '
             f'--location={hostname} --log-to-file')
         time.sleep(1)
         self.running = True
@@ -120,7 +113,7 @@ Options:
 
     def launch_engines(self):
         if not self.running:
-            if self._args['mpi']:
+            if self.args.mpi:
                 self._launch_engines_mpi()
             else:
                 self._launch_engines_local()
@@ -148,12 +141,14 @@ Options:
 
     @line_magic
     def ipcluster(self, line):
-        self._args = self.parse_args(line)
-
-        if not self._args:
+        args_dict = self.parse_args(line)
+        # if the argument list is not a valid one
+        # self.parse_args returns `None`
+        if not args_dict:
             return
 
-        if self._args['start']:
+        self.args = Arguments(args_dict)
+        if self.args.start:
             self.launch_engines()
-        elif self._args['stop']:
+        elif self.args.stop:
             self.stop_cluster()

--- a/ipcmagic/utilities.py
+++ b/ipcmagic/utilities.py
@@ -44,3 +44,17 @@ def watch_asyncresult(ar, dt=1, truncate=1000):
 
     if 'error' in ar.status or None in ar.status:
         ar.display_outputs()
+
+
+class Arguments:
+    """Utility class to treat the magic class docopt args
+    as class attribute instead of dictionary keys.
+    self.args['option'] -> self.args.option
+    """
+    def __init__(self, attr_dict):
+        if type(attr_dict) is dict:
+            # replace `-` characters inside the string
+            # like `num-engines` for instance
+            attr_dict = {key.replace('-', '_'): val
+                         for key, val in attr_dict.items()}
+            self.__dict__.update(attr_dict)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
+import os
 from setuptools import setup
 
 
+version_py = os.path.join(os.path.dirname(__file__), 'ipcmagic', 'version.py')
+version = {}
+with open(version_py) as fp:
+    exec(fp.read(), version)
+
+
 setup(name='ipcluster_magics',
-      version='1.0.1',
+      version=version['VERSION'],
       packages=['ipcmagic'],
       url='https://github.com/eth-cscs/ipcluster_magic',
       license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(name='ipcluster_magics',
-      version='1.0.0',
+      version='1.0.1',
       packages=['ipcmagic'],
       url='https://github.com/eth-cscs/ipcluster_magic',
       license='BSD',
@@ -11,6 +11,7 @@ setup(name='ipcluster_magics',
       install_requires=[
           'ipython>=6.3.0',
           'pexpect>=4.8.0',
-          'docopt>==0.6.2'
+          'docopt>=0.6.2',
+          'ipyparallel>=7.0.1',
       ]
 )


### PR DESCRIPTION
This PR introduces the following:
 * the use of `ipyparallel`'s new `wait_for_engines` function for waiting for the cluster to be ready. The waiting time is now 60 seconds, which is the function's default. It used to be 24 seconds, now with 60s it covers uncommon cases where the waiting time is close to a minute. The `ipyparallel.Client` timeout was also set to the default of 10 seconds. The `timeout` arguments can be removed if preferred, they are there only as a quick reminder of the defaults.
 * fix for the version that used to be defined in two places.
 * the required version of `ipyparallel` is set.
 * command line arguments generated with `docopt` can be treated as attributes of `IPClusterMagics.args`.